### PR TITLE
Configurable Name Value Separator

### DIFF
--- a/Src/VSoft.CommandLine.Options.pas
+++ b/Src/VSoft.CommandLine.Options.pas
@@ -95,6 +95,9 @@ type
       FUnnamedOptions : TList<IOptionDefintion>;
       //all registered options.
       FRegisteredOptions : TList<IOptionDefintion>;
+      //Name-Value separator
+      FNameValueSeparator: string;
+
   protected
     class constructor Create;
     class destructor Destroy;
@@ -108,6 +111,7 @@ type
     class property RegisteredOptions : TDictionary<string,IOptionDefintion> read FOptionsLookup;
     class property RegisteredUnamedOptions : TList<IOptionDefintion> read FUnnamedOptions;
     class procedure PrintUsage(const proc : TProc<string>);
+    class property NameValueSeparator: string read FNameValueSeparator write FNameValueSeparator;
   end;
 
 implementation
@@ -143,7 +147,7 @@ class function TOptionsRegistry.Parse: ICommandLineParseResult;
 var
   parser : ICommandLineParser;
 begin
-  parser := TCommandLineParser.Create;
+  parser := TCommandLineParser.Create(NameValueSeparator);
   result := parser.Parse;
 end;
 
@@ -157,7 +161,7 @@ begin
   FOptionsLookup := TDictionary<string,IOptionDefintion>.Create;
   FUnnamedOptions := TList<IOptionDefintion>.Create;
   FRegisteredOptions := TList<IOptionDefintion>.Create;
-
+  FNameValueSeparator := ':';
 end;
 
 class destructor TOptionsRegistry.Destroy;
@@ -171,7 +175,7 @@ class function TOptionsRegistry.Parse(const values: TStrings): ICommandLineParse
 var
   parser : ICommandLineParser;
 begin
-  parser := TCommandLineParser.Create;
+  parser := TCommandLineParser.Create(NameValueSeparator);
   result := parser.Parse(values);
 end;
 

--- a/Src/VSoft.CommandLine.Parser.pas
+++ b/Src/VSoft.CommandLine.Parser.pas
@@ -55,6 +55,7 @@ type
   TCommandLineParser = class(TInterfacedObject,ICommandLineParser)
   private
     FUnamedIndex : integer;
+    FNameValueSeparator: string;
   protected
     procedure InternalValidate(const parseErrors : IParseResultAddError);
 
@@ -64,7 +65,7 @@ type
     function Parse: ICommandLineParseResult;overload;
     function Parse(const values : TStrings) : ICommandLineParseResult;overload;
   public
-    constructor Create;
+    constructor Create(const ANameValueSeparator: string);
     destructor Destroy;override;
   end;
 
@@ -92,9 +93,11 @@ end;
 
 { TCommandLineParser }
 
-constructor TCommandLineParser.Create;
+constructor TCommandLineParser.Create(const ANameValueSeparator: string);
 begin
+  inherited Create;
   FUnamedIndex := 0;
+  FNameValueSeparator := ANameValueSeparator;
 end;
 
 destructor TCommandLineParser.Destroy;
@@ -145,12 +148,12 @@ begin
     end;
 
     if bTryValue then
-      j := Pos(':',value);
+      j := Pos(FNameValueSeparator,value);
     if j > 0 then
     begin
       //separate out into key and value
       key := Copy(value,1,j-1);
-      Delete(value,1,j);
+      Delete(value,1,j + Length(FNameValueSeparator) - 1);
       //it should already come in here without quotes when parsing paramstr(x).
       //but it might have quotes if it came in from a parameter file;
       StripQuotes(value);

--- a/Tests/TestCommandLineParser.pas
+++ b/Tests/TestCommandLineParser.pas
@@ -92,6 +92,12 @@ type
   [Test]
   procedure Will_Generate_Error_For_Invalid_Set;
 
+  [Test]
+  procedure Can_Parse_EqualNameValueSeparator;
+
+  [Test]
+  procedure Can_Parse_ColonEqualNameValueSeparator;
+
   end;
 
 implementation
@@ -225,6 +231,55 @@ begin
   Assert.IsFalse(parseResult.HasErrors);
   Assert.AreEqual<TExampleSet>(test,[enOne,enThree]);
 end;
+
+procedure TCommandLineParserTests.Can_Parse_EqualNameValueSeparator;
+var
+  def : IOptionDefintion;
+  test : string;
+  parseResult : ICommandLineParseResult;
+  sList : TStringList;
+begin
+  def := TOptionsRegistry.RegisterOption<string>('test','t',
+                  procedure(value : string)
+                  begin
+                    test := value;
+                  end);
+
+  sList := TStringList.Create;
+  sList.Add('--test=hello');
+  try
+    TOptionsRegistry.NameValueSeparator := '=';
+    parseResult := TOptionsRegistry.Parse(sList);
+  finally
+    sList.Free;
+  end;
+  Assert.AreEqual('hello',test);
+end;
+
+procedure TCommandLineParserTests.Can_Parse_ColonEqualNameValueSeparator;
+var
+  def : IOptionDefintion;
+  test : string;
+  parseResult : ICommandLineParseResult;
+  sList : TStringList;
+begin
+  def := TOptionsRegistry.RegisterOption<string>('test','t',
+                  procedure(value : string)
+                  begin
+                    test := value;
+                  end);
+
+  sList := TStringList.Create;
+  sList.Add('--test:=hello');
+  try
+    TOptionsRegistry.NameValueSeparator := ':=';
+    parseResult := TOptionsRegistry.Parse(sList);
+  finally
+    sList.Free;
+  end;
+  Assert.AreEqual('hello',test);
+end;
+
 
 procedure TCommandLineParserTests.Can_Parse_Unnamed_Parameter;
 var


### PR DESCRIPTION
Added a class-property on TOptionsRegistry to specify a name-value-separator. Default is still ":"
