### PR TITLE
Parameter Files will now be read

### DIFF
--- a/Src/VSoft.CommandLine.Parser.pas
+++ b/Src/VSoft.CommandLine.Parser.pas
@@ -224,6 +224,7 @@ var
 begin
   sList := TStringList.Create;
   try
+    sList.LoadFromFile(fileName);
     InternalParse(sList,parseErrors);
   finally
     sList.Free;


### PR DESCRIPTION
Previously option/parameter files were not read in. The
InternalParseFile function would simply ignore the filename passed to
it.