### PR TITLE
Fixing issue to key-only last option

### DIFF
--- a/Src/VSoft.CommandLine.Parser.pas
+++ b/Src/VSoft.CommandLine.Parser.pas
@@ -197,6 +197,12 @@ begin
             value := ''
           else
             Inc(i);
+        end
+        else
+        begin
+          //the last option with no value just a key
+          key := value;
+          value := '';
         end;
       end
       else


### PR DESCRIPTION
When a key-only option is used as the last argument, it is invoking the last key action. 
For instance: 
  builder create --name test -verbose
The verbose option would call the name action, instead.